### PR TITLE
fix: reformat how slugs are defined

### DIFF
--- a/adex/src/app.js
+++ b/adex/src/app.js
@@ -48,8 +48,10 @@ function ComponentWrapper({ url = '' }) {
         Router,
         null,
         routes.map(d => {
+          const routePath = d.routePath.replace(/\/\*(\w+)/, '/:$1*')
+
           return h(Route, {
-            path: normalizeURLPath(d.routePath),
+            path: normalizeURLPath(routePath),
             component: lazy(d.module),
           })
         })


### PR DESCRIPTION
Missed a change in the client side router while moving to new `pathtoregexp` on the server, this is for catch-all slug handling